### PR TITLE
Fix use of void variable

### DIFF
--- a/greek-unicode-insert.el
+++ b/greek-unicode-insert.el
@@ -59,7 +59,8 @@
 ;;;###autoload
 (progn
   (define-prefix-command 'greek-unicode-insert-map)
-  (global-set-key greek-unicode-insert-key 'greek-unicode-insert-map)
+  (when (boundp 'greek-unicode-insert-key)
+    (global-set-key greek-unicode-insert-key 'greek-unicode-insert-map))
 
   ;; Lowercase Greek
   (define-key greek-unicode-insert-map "\M-s" "ς")


### PR DESCRIPTION
The `greek-unicode-insert-key` option was removed in an earlier commit, but its use was then added back without checking that it was set. This commit introduces such a check, so that the code works according to the new instructions, as well as for those who have previously set `greek-unicode-insert-key`.
